### PR TITLE
Print error detail when failed hashing

### DIFF
--- a/tasks/cache_manage.js
+++ b/tasks/cache_manage.js
@@ -57,7 +57,7 @@ module.exports = function(grunt) {
       var file = files[key];
       hash(file, options, function(error, data) {
         if (error) {
-          throw new Error('failed hashing.');
+          throw new Error('failed hashing. (' + error.toString() + ')');
         }
         values[key] = data;
         callback();


### PR DESCRIPTION
We cant know what error has occured because we got only 'failed hashing.' when error occured.
This PR make it possible to know error detail.